### PR TITLE
Implementing _printf main behaviour (#2)

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -99,13 +99,6 @@ int _printf(const char *format, ...)
 		i++;
 	}
 
-	/* @remove random printf to avoid "unused variable" compil error. */
-	/* printf("%s\n", format); */
-	/* Thanks ChatGPT for this tip. Avoids "unused variable" error. */
-	(void)supported_formats;
-	(void)conversion_delimiter;
-	(void)format;
-
 	va_end(components);
 
 	return (total);

--- a/_printf.c
+++ b/_printf.c
@@ -1,6 +1,7 @@
 /* Orchestrator function for formatted printing */
 #include "main.h"
-#include <stdarg.h>
+#include <stdarg.h> /* Required for variadic parsing.    */
+#include <unistd.h> /* Required for write standard func. */
 
 #include <stdio.h> /* Temporary */
 
@@ -32,6 +33,20 @@ int (**get_supported_formats(void))(va_list)
 }
 
 /**
+ * print_single_char - Helper function to print
+ *   just a single character without call to variadic.
+ * @c: character to print.
+ * Return: 1 if success (to increment total count of chars printed).
+ */
+int print_single_char(char c)
+{
+	if (c == '\0')
+		return (-1);
+	else
+		return (write(1, &c, 1));
+}
+
+/**
  * _printf - Prints formatted strings to standard output.
  * @format: string mixing literal characters, format introducer (%)
  *     and format identifiers ('c', 'i', 's', 'f').
@@ -55,6 +70,7 @@ int _printf(const char *format, ...)
 
 	va_list components; /* Variadic list of "string components" */
 	int total;          /* Total number of characters outputted */
+	unsigned int i = 0; /* Cursor used to traverse "format"     */
 
 	supported_formats = get_supported_formats();
 
@@ -62,12 +78,25 @@ int _printf(const char *format, ...)
 		return (-1);      /* Seems fair to return negative for error. */
 
 	va_start(components, format);
+	while (format[i])
+	{
+		if (format[i] == conversion_delimiter)
+		{
+			break;
+		}
+		else
+		{
+			print_single_char(format[i]);
+			i++;
+		}
+	}
 
 	/* @remove random printf to avoid "unused variable" compil error. */
-	printf("%s\n", format);
+	/* printf("%s\n", format); */
 	/* Thanks ChatGPT for this tip. Avoids "unused variable" error. */
 	(void)supported_formats;
 	(void)conversion_delimiter;
+	(void)format;
 
 	va_end(components);
 

--- a/_printf.c
+++ b/_printf.c
@@ -67,16 +67,14 @@ int _printf(const char *format, ...)
 {
 	int (**supported_formats)(va_list);
 	char conversion_delimiter = '%';
-
 	va_list components; /* Variadic list of "string components" */
 	int total = 0;      /* Total number of characters outputted */
 	unsigned int i = 0; /* Cursor used to traverse "format"     */
 
-	supported_formats = get_supported_formats();
-
 	if (format == NULL) /* Guard clause */
 		return (-1);      /* Seems fair to return negative for error. */
 
+	supported_formats = get_supported_formats();
 	va_start(components, format);
 	while (format[i])
 	{

--- a/_printf.c
+++ b/_printf.c
@@ -1,0 +1,33 @@
+/* Orchestrator function for formatted printing */
+#include "main.h"
+#include <stdarg.h>
+
+#include <stdio.h> /* Temporary */
+/**
+ * _printf - Prints formatted strings to standard output.
+ * @format: string mixing literal characters, format introducer (%)
+ *     and format identifiers ('c', 'i', 's', 'f').
+ *     The chain of format introducer and format identifier creates
+ *       a "conversion command".
+ * @...: variadic number of additional arguments.
+ *   This chain of arguments must normally have a number of arguments
+ *   equal to the number of "conversion commands".
+ *
+ * Return: integer representing total number of characters outputted.
+ * 
+ * Description: outputs a string composed of literal characters 
+ *   and formatable named components on the file descriptor 1
+ *   which is usually an end-user's interface (ex terminal screen).
+ *
+ */
+int _printf(const char *format, ...)
+{
+  int total;  /* Total number of characters outputted */
+
+  /* @remove random printf to avoid "unused variable" compil error. */
+  printf("%s\n", format);
+
+  total = 0;
+  return (total);
+}
+

--- a/_printf.c
+++ b/_printf.c
@@ -80,36 +80,23 @@ int _printf(const char *format, ...)
 	va_start(components, format);
 	while (format[i])
 	{
-		if (format[i] == conversion_delimiter)
+		if (format[i] == conversion_delimiter && format[i + 1] != '\0')
 		{
-			if (format[i + 1] == '\0')
-			{
-				print_single_char('%');
-				i++;
-			}
-			else if (format[i + 1] == '%')
-			{
-				print_single_char('%');
-				i += 2;
-			}
+			if (format[i + 1] == '%')
+				print_single_char(format[i++]);
 			else if (supported_formats[(int)format[i + 1]])
 			{
-				/* Implement a function to look for format */
 				supported_formats[(int)format[i + 1]](components);
-				i += 2;
+				i += 1;
 			}
 			else
-			{
 				print_single_char(format[i]);
-				print_single_char(format[i + 1]);
-				i += 2;
-			}
 		}
 		else
 		{
 			print_single_char(format[i]);
-			i++;
 		}
+		i++;
 	}
 
 	/* @remove random printf to avoid "unused variable" compil error. */

--- a/_printf.c
+++ b/_printf.c
@@ -92,9 +92,17 @@ int _printf(const char *format, ...)
 				print_single_char('%');
 				i += 2;
 			}
-			else
+			else if (supported_formats[(int)format[i + 1]])
 			{
 				/* Implement a function to look for format */
+				supported_formats[(int)format[i + 1]](components);
+				i += 2;
+			}
+			else
+			{
+				print_single_char(format[i]);
+				print_single_char(format[i + 1]);
+				i += 2;
 			}
 		}
 		else

--- a/_printf.c
+++ b/_printf.c
@@ -69,7 +69,7 @@ int _printf(const char *format, ...)
 	char conversion_delimiter = '%';
 
 	va_list components; /* Variadic list of "string components" */
-	int total;          /* Total number of characters outputted */
+	int total = 0;      /* Total number of characters outputted */
 	unsigned int i = 0; /* Cursor used to traverse "format"     */
 
 	supported_formats = get_supported_formats();
@@ -83,18 +83,18 @@ int _printf(const char *format, ...)
 		if (format[i] == conversion_delimiter && format[i + 1] != '\0')
 		{
 			if (format[i + 1] == '%')
-				print_single_char(format[i++]);
+				total += print_single_char(format[i++]);
 			else if (supported_formats[(int)format[i + 1]])
 			{
-				supported_formats[(int)format[i + 1]](components);
+				total += supported_formats[(int)format[i + 1]](components);
 				i += 1;
 			}
 			else
-				print_single_char(format[i]);
+				total += print_single_char(format[i]);
 		}
 		else
 		{
-			print_single_char(format[i]);
+			total += print_single_char(format[i]);
 		}
 		i++;
 	}
@@ -108,7 +108,6 @@ int _printf(const char *format, ...)
 
 	va_end(components);
 
-	total = 0;
 	return (total);
 }
 

--- a/_printf.c
+++ b/_printf.c
@@ -3,6 +3,35 @@
 #include <stdarg.h>
 
 #include <stdio.h> /* Temporary */
+
+/* "Local helpers for _printf */
+
+/**
+ * get_supported_formats - Initializes a correspondance table
+ *   for _printf to know which characters matches supported formats.
+ * Return: a pointer to the first element of a table of function pointers.
+ *
+ * NOTE: wouldn't have managed to "extract" the table from _printf body
+ *   to use a helper function without help from IA. Double pointers are hard.
+ */
+int (**get_supported_formats(void))(va_list)
+{
+	static int (*table[128])(va_list); /* all entries automatically NULL */
+	/* Affecting only the "character index" which we want to support.    */
+	/*  Value should always be the name of a function declared in main.h */
+	/* table['c'] = print_character; */
+	/* table['s'] = print_string;    */
+	/* table['d'] = print_decimal;   */
+	/* table['i'] = print_decimal;   */ /* @note behaves like 'd' in printf. */
+	/* table['o'] = print_octal;     */
+	/* table['u'] = print_unsigned;   */
+	/* table['x'] = print_hexadecimal_lowercase;   */
+	/* table['X'] = print_hexadecimal_uppercase;   */
+
+
+	return (table);
+}
+
 /**
  * _printf - Prints formatted strings to standard output.
  * @format: string mixing literal characters, format introducer (%)
@@ -14,20 +43,25 @@
  *   equal to the number of "conversion commands".
  *
  * Return: integer representing total number of characters outputted.
- * 
- * Description: outputs a string composed of literal characters 
+ *
+ * Description: outputs a string composed of literal characters
  *   and formatable named components on the file descriptor 1
  *   which is usually an end-user's interface (ex terminal screen).
  *
  */
 int _printf(const char *format, ...)
 {
-  int total;  /* Total number of characters outputted */
+	int (**supported_formats)(va_list);
+	int total;         /* Total number of characters outputted */
 
-  /* @remove random printf to avoid "unused variable" compil error. */
-  printf("%s\n", format);
+	supported_formats = get_supported_formats();
 
-  total = 0;
-  return (total);
+	/* @remove random printf to avoid "unused variable" compil error. */
+	printf("%s\n", format);
+	/* Thanks ChatGPT for this tip. Avoids "unused variable" error. */
+	(void)supported_formats;
+
+	total = 0;
+	return (total);
 }
 

--- a/_printf.c
+++ b/_printf.c
@@ -82,7 +82,20 @@ int _printf(const char *format, ...)
 	{
 		if (format[i] == conversion_delimiter)
 		{
-			break;
+			if (format[i + 1] == '\0')
+			{
+				print_single_char('%');
+				i++;
+			}
+			else if (format[i + 1] == '%')
+			{
+				print_single_char('%');
+				i += 2;
+			}
+			else
+			{
+				/* Implement a function to look for format */
+			}
 		}
 		else
 		{

--- a/_printf.c
+++ b/_printf.c
@@ -83,20 +83,22 @@ int _printf(const char *format, ...)
 		if (format[i] == conversion_delimiter && format[i + 1] != '\0')
 		{
 			if (format[i + 1] == '%')
-				total += print_single_char(format[i++]);
+				total += print_single_char('%');
 			else if (supported_formats[(int)format[i + 1]])
-			{
 				total += supported_formats[(int)format[i + 1]](components);
-				i += 1;
-			}
 			else
+			{
 				total += print_single_char(format[i]);
+				total += print_single_char(format[i + 1]);
+			}
+			i += 2;
+			continue;
 		}
 		else
 		{
 			total += print_single_char(format[i]);
+			i++;
 		}
-		i++;
 	}
 
 	va_end(components);

--- a/_printf.c
+++ b/_printf.c
@@ -28,7 +28,6 @@ int (**get_supported_formats(void))(va_list)
 	/* table['x'] = print_hexadecimal_lowercase;   */
 	/* table['X'] = print_hexadecimal_uppercase;   */
 
-
 	return (table);
 }
 
@@ -52,14 +51,25 @@ int (**get_supported_formats(void))(va_list)
 int _printf(const char *format, ...)
 {
 	int (**supported_formats)(va_list);
-	int total;         /* Total number of characters outputted */
+	char conversion_delimiter = '%';
+
+	va_list components; /* Variadic list of "string components" */
+	int total;          /* Total number of characters outputted */
 
 	supported_formats = get_supported_formats();
+
+	if (format == NULL) /* Guard clause */
+		return (-1);      /* Seems fair to return negative for error. */
+
+	va_start(components, format);
 
 	/* @remove random printf to avoid "unused variable" compil error. */
 	printf("%s\n", format);
 	/* Thanks ChatGPT for this tip. Avoids "unused variable" error. */
 	(void)supported_formats;
+	(void)conversion_delimiter;
+
+	va_end(components);
 
 	total = 0;
 	return (total);


### PR DESCRIPTION
### EN Summary
Creates the file _printf.c which for now holds, in addition to the function of same name, two small "utilities" it uses directly (first to generate the correspondance table "specifier -> dedicated function", second to manage the "just print current character literally" case).
Contains all the logic to make it work, are just missing the "activations" of functions in correspondance table.

### Résumé FR
Créée le fichier _printf qui contient, outre la fonction du même nom, deux petites fonctions utilitaires utilisées dans _printf (l'une pour générer la table de correspondance "spécificateur -> fonction dédiée", l'autre pour gérer le cas "imprimer littéralement le caractère courant).
Contient toute la logique d'orchestration, il ne reste plus qu'à "activer" les fonctions en modifiant la table de corespondance au fil des ajouts des fonctions dédiées.