### PR TITLE
Changing program behaviour for when parsed character is EOL + adding assorted "single character" tests

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -40,10 +40,7 @@ int (**get_supported_formats(void))(va_list)
  */
 int print_single_char(char c)
 {
-	if (c == '\0')
-		return (-1);
-	else
-		return (write(1, &c, 1));
+	return (write(1, &c, 1));
 }
 
 /**

--- a/print_character.c
+++ b/print_character.c
@@ -19,8 +19,5 @@ int print_character(va_list components)
 	char c;
 
 	c = (char)va_arg(components, int);
-	if (c == '\0')
-		return (0);
-	else
-		return (write(1, &c, 1));
+	return (write(1, &c, 1));
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -2,6 +2,7 @@
 #include <limits.h>
 #include "main.h"
 
+
 /**
  * main - Test suite for _printf
  *
@@ -11,29 +12,67 @@ int main(void)
 {
 	int len, len2;
 
-	printf("--- TEST 1: Strings ---\n");
-	len = _printf("Perso: %s\n", "Hello World");
-	len2 = printf("Standard: %s\n", "Hello World");
+	printf("--- TEST 01: Strings ---\n");
+	len = _printf("Underscore: %s\n", "Hello World");
+	len2 = printf("StdLibrary: %s\n", "Hello World");
 	printf("Lengths: [%d, %d]\n\n", len, len2);
 
-	printf("--- TEST 2: NULL String ---\n");
-	len = _printf("Perso: %s\n", NULL);
-	len2 = printf("Standard: %s\n", NULL);
+	printf("--- TEST 02: NULL String ---\n");
+	len = _printf("Underscore: %s\n", NULL);
+	len2 = printf("StdLibrary: %s\n", NULL);
 	printf("Lengths: [%d, %d]\n\n", len, len2);
 
-	printf("--- TEST 3: Integers ---\n");
-	len = _printf("Perso: %d, %i\n", -1024, 2024);
-	len2 = printf("Standard: %d, %i\n", -1024, 2024);
+	printf("--- TEST 03: Integers ---\n");
+	len = _printf("Underscore: %d, %i\n", -1024, 2024);
+	len2 = printf("StdLibrary: %d, %i\n", -1024, 2024);
 	printf("Lengths: [%d, %d]\n\n", len, len2);
 
-	printf("--- TEST 4: INT_MIN & INT_MAX ---\n");
-	len = _printf("Perso: %d, %d\n", INT_MIN, INT_MAX);
-	len2 = printf("Standard: %d, %d\n", INT_MIN, INT_MAX);
+	printf("--- TEST 04: INT_MIN & INT_MAX ---\n");
+	len = _printf("Underscore: %d, %d\n", INT_MIN, INT_MAX);
+	len2 = printf("StdLibrary: %d, %d\n", INT_MIN, INT_MAX);
 	printf("Lengths: [%d, %d]\n\n", len, len2);
 
-	printf("--- TEST 5: Percent ---\n");
-	len = _printf("Perso: %%\n");
-	len2 = printf("Standard: %%\n");
+	printf("--- TEST 05: Percent ---\n");
+	len = _printf("Underscore: %%\n");
+	len2 = printf("StdLibrary: %%\n");
+	printf("Lengths: [%d, %d]\n", len, len2);
+
+	printf("--- TEST 06: Lone EOL character ---\n");
+	printf("Underscore with char formatter: ");
+	len = _printf("%c", '\0');
+	printf("\n");
+	printf("StdLibrary with char formatter: ");
+	len2 = printf("%c", '\0');
+	printf("\n");
+	printf("Lengths: [%d, %d]\n", len, len2);
+
+	printf("Underscore as literal: ");
+	len = _printf("%c", '\0');
+	printf("\n");
+	printf("StdLibrary as literal: ");
+	len2 = printf("%c", '\0');
+	printf("\n");
+	printf("Lengths: [%d, %d]\n", len, len2);
+	
+
+	printf("--- TEST 07a: Single plain ASCII character ('z') ---\n");
+	printf("Underscore: ");
+	fflush(stdout); /* Forces to empty the stdout buffer. */
+	len = _printf("z");
+	printf("\n");
+	printf("StdLibrary: ");
+	len2 = printf("z");
+	printf("\n");
+	printf("Lengths: [%d, %d]\n", len, len2);
+
+	printf("--- TEST 07b: Single plain UTF8 character ('é') ---\n");
+	printf("Underscore: ");
+	fflush(stdout); /* Required because no \n on previous printf call */
+	len = _printf("é");
+	printf("\n");
+	printf("StdLibrary: ");
+	len2 = printf("é");
+	printf("\n");
 	printf("Lengths: [%d, %d]\n", len, len2);
 
 	return (0);


### PR DESCRIPTION
### Summary
Program now counts '\0' as a printed character like others.
As printf considers this a valid character and thus "prints it" (and return 1) even though technically nothing is displayed.
And we must be as close as possible to printf's behaviour.

Took the occasion to add a few tests variants for the "print single character" use-case.

### Résumé
Le programme ajoute désormais '\0' au compte de caractères imprimés comme les autres.
Car c'est le comportement de printf, et on doit s'en approcher autant que possible (au moins pour les comportements valides).
Ce changement s'assortit de nouveaux tests pour le cas d'usage "imprimer un seul caractère".