### PR TITLE
Feat: additional formatters + "writing failure" code from subprinters handling.

### DIFF
--- a/_printf.c
+++ b/_printf.c
@@ -8,14 +8,14 @@
 /* "Local helpers for _printf */
 
 /**
- * get_supported_formats - Initializes a correspondance table
+ * get_subprinters - Initializes a correspondance table
  *   for _printf to know which characters matches supported formats.
  * Return: a pointer to the first element of a table of function pointers.
  *
  * NOTE: wouldn't have managed to "extract" the table from _printf body
  *   to use a helper function without help from IA. Double pointers are hard.
  */
-int (**get_supported_formats(void))(va_list)
+int (**get_subprinters(void))(va_list)
 {
 	static int (*table[128])(va_list); /* all entries automatically NULL */
 	/* Affecting only the "character index" which we want to support.    */
@@ -52,12 +52,12 @@ int print_single_char(char c, int *total)
 }
 
 /**
- * delegate_print - Helper function which encapsulates prints to manage error.
+ * delegate_to - Helper function which encapsulates prints to manage error.
  * @printer: pointer to a dedicated printing function.
  * @components: variadic list to propagate to dedicated printer.
  * @total: pointer to an integer used to count overall amount of printed chars.
  *
- * Return: 0 on success, -1 if error ("bubbling up" return from write.)
+ * Return: >=0 on success, -1 if error ("bubbling up" return from write.)
  *
  * NOTES:
  * 1/ Had to use a subfunction to make the indirection because taking care
@@ -66,18 +66,15 @@ int print_single_char(char c, int *total)
  * 2/ Had to affect total directly "by passing pointer" because
  *    just bubbling up would have ended up with the same problem.
  */
-int delegate_print(int (*printer)(va_list), va_list components, int *total)
+int delegate_to(int (*printer)(va_list), va_list components, int *total)
 {
 	int count;
 
 	count = printer(components);
-	if (count == -1)
-		return (-1);
-	else
-	{
+	if (count >= 0)
 		*total += count;
-		return (0);
-	}
+
+	return (count);
 }
 
 /**
@@ -99,43 +96,41 @@ int delegate_print(int (*printer)(va_list), va_list components, int *total)
  */
 int _printf(const char *format, ...)
 {
-	int (**supported_formats)(va_list);
+	int (**subprinters)(va_list);
 	char conversion_delimiter = '%';
 	va_list components; /* Variadic list of "string components" */
 	int total = 0;      /* Total number of characters outputted */
 	unsigned int i = 0; /* Cursor used to traverse "format"     */
-	int (*subprinter)(va_list); /* Required for printing through delegation.*/
-	int subprinter_return = 0; /* Used to bubble up potential error return. */
+	int spr = 0; /* Subprinter_return: used to bubble up (error) return. */
 
 	if (format == NULL) /* Guard clause */
 		return (-1);      /* Seems fair to return negative for error. */
-	supported_formats = get_supported_formats();
+	subprinters = get_subprinters();
 	va_start(components, format);
 	while (format[i])
 	{
 		if (format[i] == conversion_delimiter && format[i + 1] != '\0')
 		{
 			if (format[i + 1] == '%')
-				subprinter_return = print_single_char('%', &total);
-			else if (supported_formats[(int)format[i + 1]])
+				spr = print_single_char('%', &total);
+			else if (subprinters[(int)format[i + 1]])
 			{
-				subprinter = supported_formats[(int)format[i + 1]];
-				subprinter_return = delegate_print(subprinter, components, &total);
+				spr = delegate_to(subprinters[(int)format[i + 1]], components, &total);
 			}
 			else
 			{
-				subprinter_return = print_single_char(format[i], &total);
-				subprinter_return = print_single_char(format[i + 1], &total);
+				spr = print_single_char(format[i], &total);
+				spr = print_single_char(format[i + 1], &total);
 			}
 			i += 2;
 			continue;
 		}
 		else
 		{
-			subprinter_return = print_single_char(format[i], &total);
+			spr = print_single_char(format[i], &total);
 			i++;
 		}
-		if (subprinter_return < 0)
+		if (spr < 0)
 			return (-1);
 	}
 	va_end(components);

--- a/_printf.c
+++ b/_printf.c
@@ -26,8 +26,8 @@ int (**get_subprinters(void))(va_list)
 	table['i'] = print_decimal;
 	table['o'] = print_octal;
 	/* table['u'] = print_unsigned;   */
-	/* table['x'] = print_hexadecimal_lowercase;   */
-	/* table['X'] = print_hexadecimal_uppercase;   */
+	table['x'] = print_hexadecimal_lowercase;
+	table['X'] = print_hexadecimal_uppercase;
 
 	return (table);
 }

--- a/_printf.c
+++ b/_printf.c
@@ -36,11 +36,48 @@ int (**get_supported_formats(void))(va_list)
  * print_single_char - Helper function to print
  *   just a single character without call to variadic.
  * @c: character to print.
- * Return: 1 if success (to increment total count of chars printed).
+ * @total: pointer to the total to increment.
+ * Return: >=0 if success (total is incremented "inplace")
+ *   or -1 if failure (bubbling up write error code).
  */
-int print_single_char(char c)
+int print_single_char(char c, int *total)
 {
-	return (write(1, &c, 1));
+	int write_successful = 0;
+
+	write_successful = write(1, &c, 1);
+	if (write_successful >= 0)
+		*total += write_successful;
+
+	return (write_successful);
+}
+
+/**
+ * delegate_print - Helper function which encapsulates prints to manage error.
+ * @printer: pointer to a dedicated printing function.
+ * @components: variadic list to propagate to dedicated printer.
+ * @total: pointer to an integer used to count overall amount of printed chars.
+ *
+ * Return: 0 on success, -1 if error ("bubbling up" return from write.)
+ *
+ * NOTES:
+ * 1/ Had to use a subfunction to make the indirection because taking care
+ *    of the "case failure in writing" in _printf
+ *    would have made n° of lines explode.
+ * 2/ Had to affect total directly "by passing pointer" because
+ *    just bubbling up would have ended up with the same problem.
+ */
+int delegate_print(int (*printer)(va_list), va_list components, int *total)
+{
+	int count;
+
+	count = printer(components);
+	if (count == -1)
+		return (-1);
+	else
+	{
+		*total += count;
+		return (0);
+	}
 }
 
 /**
@@ -67,10 +104,11 @@ int _printf(const char *format, ...)
 	va_list components; /* Variadic list of "string components" */
 	int total = 0;      /* Total number of characters outputted */
 	unsigned int i = 0; /* Cursor used to traverse "format"     */
+	int (*subprinter)(va_list); /* Required for printing through delegation.*/
+	int subprinter_return = 0; /* Used to bubble up potential error return. */
 
 	if (format == NULL) /* Guard clause */
 		return (-1);      /* Seems fair to return negative for error. */
-
 	supported_formats = get_supported_formats();
 	va_start(components, format);
 	while (format[i])
@@ -78,26 +116,29 @@ int _printf(const char *format, ...)
 		if (format[i] == conversion_delimiter && format[i + 1] != '\0')
 		{
 			if (format[i + 1] == '%')
-				total += print_single_char('%');
+				subprinter_return = print_single_char('%', &total);
 			else if (supported_formats[(int)format[i + 1]])
-				total += supported_formats[(int)format[i + 1]](components);
+			{
+				subprinter = supported_formats[(int)format[i + 1]];
+				subprinter_return = delegate_print(subprinter, components, &total);
+			}
 			else
 			{
-				total += print_single_char(format[i]);
-				total += print_single_char(format[i + 1]);
+				subprinter_return = print_single_char(format[i], &total);
+				subprinter_return = print_single_char(format[i + 1], &total);
 			}
 			i += 2;
 			continue;
 		}
 		else
 		{
-			total += print_single_char(format[i]);
+			subprinter_return = print_single_char(format[i], &total);
 			i++;
 		}
+		if (subprinter_return < 0)
+			return (-1);
 	}
-
 	va_end(components);
-
 	return (total);
 }
 

--- a/_printf.c
+++ b/_printf.c
@@ -24,7 +24,7 @@ int (**get_subprinters(void))(va_list)
 	table['s'] = print_string;
 	table['d'] = print_decimal;
 	table['i'] = print_decimal;
-	/* table['o'] = print_octal;     */
+	table['o'] = print_octal;
 	/* table['u'] = print_unsigned;   */
 	/* table['x'] = print_hexadecimal_lowercase;   */
 	/* table['X'] = print_hexadecimal_uppercase;   */

--- a/main.h
+++ b/main.h
@@ -1,8 +1,9 @@
 #ifndef MAIN_H
 #define MAIN_H
 
-/* Required so compiler "understands" va_list as variable type. */
-#include <stdarg.h>
+
+#include <stdarg.h> /* Required for "va_list" variable type. */
+#include <stddef.h> /* Required for "size_t"  variable type. */
 
 /* On screen printer of formatted strings (limited format support) */
 int _printf(const char *format, ...);
@@ -15,5 +16,12 @@ int print_decimal(va_list);
 int print_unsigned(va_list);
 int print_octal(va_list);
 int print_hexadecimal(va_list);
+
+/* Helper functions and related constants */
+/* Base 10 to base 2 <= x <= 16 number conversion helper. */
+/* @warning DO NOT USE '=' AND DO NOT end with ; */
+#define CONVERT_MAX_BUFFER 65
+char *convert_decimal_up_to_base_16(int number, unsigned int base,
+																		char *buffer, size_t buffer_size);
 
 #endif

--- a/main.h
+++ b/main.h
@@ -15,7 +15,8 @@ int print_string(va_list);
 int print_decimal(va_list);
 int print_unsigned(va_list);
 int print_octal(va_list);
-int print_hexadecimal(va_list);
+int print_hexadecimal_lowercase(va_list);
+int print_hexadecimal_uppercase(va_list);
 
 /* Helper functions and related constants */
 /* Base 10 to base 2 <= x <= 16 number conversion helper. */
@@ -23,6 +24,6 @@ int print_hexadecimal(va_list);
 #define CONVERT_MAX_BUFFER 65
 char *convert_signed_decimal_up_to_base_16(int number, unsigned int base,
 																		char *buffer, size_t buffer_size);
-char *convert_unsigned_decimal_up_to_base_16(unsigned int number, 
+char *convert_unsigned_decimal_up_to_base_16(unsigned int number,
 								unsigned int base, char *buffer, size_t buffer_size);
 #endif

--- a/main.h
+++ b/main.h
@@ -21,7 +21,8 @@ int print_hexadecimal(va_list);
 /* Base 10 to base 2 <= x <= 16 number conversion helper. */
 /* @warning DO NOT USE '=' AND DO NOT end with ; */
 #define CONVERT_MAX_BUFFER 65
-char *convert_decimal_up_to_base_16(int number, unsigned int base,
+char *convert_signed_decimal_up_to_base_16(int number, unsigned int base,
 																		char *buffer, size_t buffer_size);
-
+char *convert_unsigned_decimal_up_to_base_16(unsigned int number, 
+								unsigned int base, char *buffer, size_t buffer_size);
 #endif

--- a/print_hexadecimal.c
+++ b/print_hexadecimal.c
@@ -1,0 +1,46 @@
+#include "main.h"
+#include <unistd.h>
+
+/**
+ * hex_helper - Engine of hexadecimal conversion
+ * @n: The number of conversion
+ * @base: The chain "0123456789abcdef" ou "0123456789ABCDEF"
+ * Return: Numbers of char printed
+ */
+static int hex_helper(unsigned int n, char *base)
+{
+	int count = 0;
+	char c;
+
+	if (n / 16)
+		count += hex_helper(n / 16, base);
+
+	c = base[n % 16];
+	write(1, &c, 1);
+
+	return (count + 1);
+}
+
+/**
+ * print_hexadecimal_lowercase - Manage %x
+ * @args: va_list
+ * Return: Number of char
+ */
+int print_hexadecimal_lowercase(va_list args)
+{
+	unsigned int n = va_arg(args, unsigned int);
+
+	return (hex_helper(n, "0123456789abcdef"));
+}
+
+/**
+ * print_hexadecimal_uppercase - Manage %X
+ * @args: va_list
+ * Return: Number of char
+ */
+int print_hexadecimal_uppercase(va_list args)
+{
+	unsigned int n = va_arg(args, unsigned int);
+
+	return (hex_helper(n, "0123456789ABCDEF"));
+}

--- a/print_octal.c
+++ b/print_octal.c
@@ -1,0 +1,35 @@
+#include <stdarg.h>
+#include <unistd.h>
+#include "main.h"
+
+/**
+ * print_octal - Prints next variadic argument "as an octal number".
+ * @components: variadic list holding component to read.
+ * Return: number of characters printed or -1 on error.
+ *
+ * NOTES
+ * 1. The caller guarantees that the specifier requests
+ *     "printing as a character". However no guarantee that
+ *     the "next variadic parameter" is indeed of the right type.
+ * 2. We arbitrarily consider that the provided number will be
+ *     of "unsigned integer" type.
+ */
+int print_octal(va_list components)
+{
+	unsigned int source; /* Arbitrary choice to restrict to unsigned. */
+	char buffer[CONVERT_MAX_BUFFER]; /* To store conversion digits.  */
+	char *converted;     /* Pointer to start of converted string      */
+	int length;          /* Size of converted string.                 */
+	int written;      /* Counts printed and can hold potential error. */
+
+	source = va_arg(components, unsigned int);
+	converted = convert_unsigned_decimal_up_to_base_16(source,
+											8, buffer, CONVERT_MAX_BUFFER);
+
+	/* Was gonna do a whole "step by step calculate length", useless! */
+	/* while (converted) */
+	length = (buffer + CONVERT_MAX_BUFFER) - converted;
+	written = write(1, converted, length);
+
+	return (written);
+}

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -77,6 +77,11 @@ int main(void)
 	printf("\n");
 	printf("Lengths: [%d, %d]\n", len, len2);
 
+	printf("--- TEST 08: Octal ---\n");
+	len = _printf("Underscore: %o, %o\n", INT_MIN, INT_MAX);
+	len2 = printf("StdLibrary: %o, %o\n", INT_MIN, INT_MAX);
+	printf("Lengths: [%d, %d]\n\n", len, len2);
+
 	/* TESTS UTILS */
 	printf("--- TEST UTILS ---\n");
 	big_decimal = -224466777;

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -56,7 +56,6 @@ int main(void)
 	len2 = printf("%c", '\0');
 	printf("\n");
 	printf("Lengths: [%d, %d]\n", len, len2);
-	
 
 	printf("--- TEST 07a: Single plain ASCII character ('z') ---\n");
 	printf("Underscore: ");
@@ -82,13 +81,13 @@ int main(void)
 	printf("--- TEST UTILS ---\n");
 	big_decimal = -224466777;
 	printf("*** Convert to lowercase hexa ***\n");
-	big_converted = convert_decimal_up_to_base_16(big_decimal, 16, convert_buff, (size_t)65);
+	big_converted = convert_signed_decimal_up_to_base_16(big_decimal, 16, convert_buff, (size_t)65);
 	len = _printf("Underscore: %s\n", big_converted);
 	len2 = printf("StdLibrary: %s\n", big_converted);
 	printf("Lengths: [%d, %d]\n", len, len2);
 
 	printf("*** Convert to octal ***\n");
-	big_converted = convert_decimal_up_to_base_16(big_decimal, 8, convert_buff, (size_t)65);
+	big_converted = convert_signed_decimal_up_to_base_16(big_decimal, 8, convert_buff, (size_t)65);
 	len = _printf("Underscore: %s\n", big_converted);
 	len2 = printf("StdLibrary: %s\n", big_converted);
 	printf("Lengths: [%d, %d]\n", len, len2);

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -14,15 +14,17 @@ int main(void)
 	int big_decimal;
 	char convert_buff[65];
 	char *big_converted;
+	unsigned int ui = 4294967295;
+	char *str_null = NULL;
 
 	printf("--- TEST 01: Strings ---\n");
 	len = _printf("Underscore: %s\n", "Hello World");
 	len2 = printf("StdLibrary: %s\n", "Hello World");
 	printf("Lengths: [%d, %d]\n\n", len, len2);
 
-	printf("--- TEST 02: NULL String ---\n");
-	len = _printf("Underscore: %s\n", NULL);
-	len2 = printf("StdLibrary: %s\n", NULL);
+	printf("--- TEST 2: NULL String ---\n");
+	len = _printf("Underscore: %s\n", str_null);
+	len2 = printf("StdLibrary: %s\n", str_null);
 	printf("Lengths: [%d, %d]\n\n", len, len2);
 
 	printf("--- TEST 03: Integers ---\n");
@@ -96,6 +98,16 @@ int main(void)
 	len = _printf("Underscore: %s\n", big_converted);
 	len2 = printf("StdLibrary: %s\n", big_converted);
 	printf("Lengths: [%d, %d]\n", len, len2);
+
+		printf("--- TEST 9: Hexadecimal Lower (%%x) ---\n");
+	len = _printf("Underscore: %x, %x, %x\n", 0, 42, ui);
+	len2 = printf("StdLibrary: %x, %x, %x\n", 0, 42, ui);
+	printf("Lengths: [%d, %d]\n\n", len, len2);
+
+	printf("--- TEST 10: Hexadecimal Upper (%%X) ---\n");
+	len = _printf("Underscore: %X, %X, %X\n", 0, 42, ui);
+	len2 = printf("StdLibrary: %X, %X, %X\n", 0, 42, ui);
+	printf("Lengths: [%d, %d]\n\n", len, len2);
 
 	return (0);
 }

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -11,6 +11,9 @@
 int main(void)
 {
 	int len, len2;
+	int big_decimal;
+	char convert_buff[65];
+	char *big_converted;
 
 	printf("--- TEST 01: Strings ---\n");
 	len = _printf("Underscore: %s\n", "Hello World");
@@ -73,6 +76,21 @@ int main(void)
 	printf("StdLibrary: ");
 	len2 = printf("é");
 	printf("\n");
+	printf("Lengths: [%d, %d]\n", len, len2);
+
+	/* TESTS UTILS */
+	printf("--- TEST UTILS ---\n");
+	big_decimal = -224466777;
+	printf("*** Convert to lowercase hexa ***\n");
+	big_converted = convert_decimal_up_to_base_16(big_decimal, 16, convert_buff, (size_t)65);
+	len = _printf("Underscore: %s\n", big_converted);
+	len2 = printf("StdLibrary: %s\n", big_converted);
+	printf("Lengths: [%d, %d]\n", len, len2);
+
+	printf("*** Convert to octal ***\n");
+	big_converted = convert_decimal_up_to_base_16(big_decimal, 8, convert_buff, (size_t)65);
+	len = _printf("Underscore: %s\n", big_converted);
+	len2 = printf("StdLibrary: %s\n", big_converted);
 	printf("Lengths: [%d, %d]\n", len, len2);
 
 	return (0);

--- a/utils.c
+++ b/utils.c
@@ -1,0 +1,57 @@
+#include <stddef.h>
+#include "main.h"
+
+/**
+ * convert_decimal_up_to_base_16 - converts a decimal into a string
+ *   representing the n in base n
+ * @n: the integer to convert (initially "number" but needed space).
+ * @base: the target base to convert it into.
+ * @buffer: char array which will store "digits" of conversion.
+ * @buffer_size: required for control AND to know provided array's end
+ *   so we can "jump to it" with our pointer.
+ *
+ * Return: string representing new character.
+ *
+ * NOTE: buffer MUST be passed as "provided by caller" because...
+ *   a) Static may lead to undesired behaviour (like simultaneous calls).
+ *   b) The smart approach of using a pointer on the buffer and returning it
+ *        once "set at the right address" cannot work if the buffer lifetime
+ *        is tied to a specific instance of the function (stack frame).
+ */
+char *convert_decimal_up_to_base_16(int n, unsigned int base,
+																		char *buffer, size_t buffer_size)
+{
+	char *digit_writer;
+	char *digits;
+	int n_is_negative;
+
+	if (!n || base < 2 || base > 16 || buffer_size > CONVERT_MAX_BUFFER)
+		return (""); /* How to properly inform "out of bounds request" ? */
+	/* if (base == 10 || n == 0 || n == 1 || (unsigned int)n == base)
+		return ((char *)n); */ /* @warning Stupid! 100% undefined behaviour. */
+	/* Digits covering up to base16 (hexadecimal) */
+	digits = "0123456789abcdef";
+	/* Pointer used to write digits in buffer. */
+	/* Since we get digits "from the least relevant first" the best is to */
+	/*   directly store from the array's end. */
+	digit_writer = buffer + buffer_size;
+	/* AND since we'll return a string we can immediately write the EOL char. */
+	*digit_writer = '\0';
+
+	/* Need to know the sign. */
+	n_is_negative = (n < 0);
+	/* Now we do a while which "moonwalks" through the array by */
+	/*   dividing n iteratively, getting "lowest significant" digit */
+	/* each time then "updating n "*/
+	/* Number not null so we are sure we can do at least one division */
+	do {
+		/* Move pointer BEFORE derefencing to not overwrite EOL. */
+		*(--digit_writer) = digits[n % base];  /* Remainder gives us the digit. */
+		n = n / base;    /* We reduce number "by one dimension" for next cycle. */
+	} while (n);               /* Process will make it end "as 0" so "false". */
+
+	if (n_is_negative)   /* How to cover case no cell left in array for sign? */
+		*(--digit_writer) = '-'; /* BEWARE of not mixing "" and ''! */
+
+	return (digit_writer);
+}

--- a/utils.c
+++ b/utils.c
@@ -18,7 +18,45 @@
  *        once "set at the right address" cannot work if the buffer lifetime
  *        is tied to a specific instance of the function (stack frame).
  */
-char *convert_decimal_up_to_base_16(int n, unsigned int base,
+char *convert_unsigned_decimal_up_to_base_16(unsigned int n, unsigned int base,
+																		char *buffer, size_t buffer_size)
+{
+	char *digit_writer;
+	char *digits;
+
+	if (!n || base < 2 || base > 16 || buffer_size > CONVERT_MAX_BUFFER)
+		return ("");
+	/* Digits covering up to base16 (hexadecimal) */
+	digits = "0123456789abcdef";
+	digit_writer = buffer + buffer_size;
+	*digit_writer = '\0';
+
+	do {
+		*(--digit_writer) = digits[n % base];
+		n = n / base;
+	} while (n);
+
+	return (digit_writer);
+}
+
+/**
+ * convert_signed_decimal_up_to_base_16 - converts a decimal into a string
+ *   representing the n in base n
+ * @n: the integer to convert (initially "number" but needed space).
+ * @base: the target base to convert it into.
+ * @buffer: char array which will store "digits" of conversion.
+ * @buffer_size: required for control AND to know provided array's end
+ *   so we can "jump to it" with our pointer.
+ *
+ * Return: string representing new character.
+ *
+ * NOTE: buffer MUST be passed as "provided by caller" because...
+ *   a) Static may lead to undesired behaviour (like simultaneous calls).
+ *   b) The smart approach of using a pointer on the buffer and returning it
+ *        once "set at the right address" cannot work if the buffer lifetime
+ *        is tied to a specific instance of the function (stack frame).
+ */
+char *convert_signed_decimal_up_to_base_16(int n, unsigned int base,
 																		char *buffer, size_t buffer_size)
 {
 	char *digit_writer;
@@ -27,9 +65,7 @@ char *convert_decimal_up_to_base_16(int n, unsigned int base,
 
 	if (!n || base < 2 || base > 16 || buffer_size > CONVERT_MAX_BUFFER)
 		return (""); /* How to properly inform "out of bounds request" ? */
-	/* if (base == 10 || n == 0 || n == 1 || (unsigned int)n == base)
-		return ((char *)n); */ /* @warning Stupid! 100% undefined behaviour. */
-	/* Digits covering up to base16 (hexadecimal) */
+		/* Digits covering up to base16 (hexadecimal) */
 	digits = "0123456789abcdef";
 	/* Pointer used to write digits in buffer. */
 	/* Since we get digits "from the least relevant first" the best is to */


### PR DESCRIPTION
This merge will bring all the following improvements and new features.

### NEW FEATURES
Support for the following conversion identifiers ("formatters")
1. '%o': using provided unsigned integer number to represent it in base 8 (octal).
2. '%x': using provided unsigned integer number to represent it in base 16 (hexadecimal) with lowercase characters.
3. '%X': using provided unsigned integer number to represent it in base 16 (hexadecimal) with UPPERCASE characters.

Any function implementing the conventional behaviour "error during attempt to write -> return -1" is now correctly handled by the main function.

Note: some tests were added to match the new formatters in test_main.