### PR TITLE
Fixes (demo compile + EOL print varying on arch + README) & Improvements (error handling for all formatters)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In case that helps here are online resources to install
 ### 1. Downloading
 If you have git and are comfortable with command line,
   you can simply open one and go to the directory in which you want calculator to be.
-  Then run (without the quotes) "git clone https://github.com/llacote-holberton/holbertonschool-printf.git"
+  Then run (without the quotes) `"git clone https://github.com/llacote-holberton/holbertonschool-printf.git"`
 Otherwise you can simply download a zip containing all projects file
   by following [this url](https://github.com/llacote-holberton/holbertonschool-printf/archive/refs/heads/main.zip)
   then unfolding it where you want on your computer.
@@ -75,7 +75,10 @@ So you will need to write your own source code implementing the "main" function 
 
 With that said, if you just want a demonstration of its output, we provide a dedicated "test main" you can use at leisure.
 Just add it to the list of files to include in compilation like so.
-`gcc -Wall -Werror -Wextra -pedantic -std=gnu89 *.c tests/test_main.c -o custom_partial_printf_demo.out`
+`gcc -Wall -Werror -Wextra -pedantic -std=gnu89 -Wno-format *.c tests/test_main.c -o custom_partial_printf_demo.out`
+
+Please be aware that for our demo example the -Wno-format flag is REQUIRED to pass compilation, as we make "side-by-side" comparisons
+  between "custom printf" and "official printf" rendering including in cases which are normally unsupported by printf (thus rejected by compiler).
 
 ### 3. Starting program
 Open a terminal place yourself in the directory in which you have downloaded/extracted the project then compiled an executable,  
@@ -202,6 +205,12 @@ or when format string has been fully parsed (then returns total characters print
 
 #### Process flow
 ![_printf Flowchart](./flowchart_printf.png)
+
+#### Notes on architecture choices
+
+1. Contrarily to printf, we print literally a character following % but not recognized as a supported conversion identifier "as a literal character". This difference comes from the fact that printf has a much wider range of features and as such often tries to "parse several consecutive characters" to find a pattern... Ending in failure in case there is no exploitable pattern. As our function is much simpler it allows us to act differently.
+
+2. For file structure we tried to be as clear as possible but our initial stance of "one function per file" evolved a bit when actual coding start. We diverged a bit from that stance in that some functions have been written "inline aside" their associated function as it didn't make much sense to "expose" them (not really reusable ones).
 
 #### Source code file structure
 | Filename                     | Role                                                                                                 | Functions in file               |

--- a/_printf.c
+++ b/_printf.c
@@ -3,8 +3,6 @@
 #include <stdarg.h> /* Required for variadic parsing.    */
 #include <unistd.h> /* Required for write standard func. */
 
-#include <stdio.h> /* Temporary */
-
 /* "Local helpers for _printf */
 
 /**

--- a/print_character.c
+++ b/print_character.c
@@ -17,7 +17,11 @@
 int print_character(va_list components)
 {
 	char c;
+	int write_return;
 
 	c = (char)va_arg(components, int);
-	return (write(1, &c, 1));
+	/* Required step to have '\0' counted irrelevant of OS and processor. */
+	write_return = (write(1, &c, 1) < 0) ? -1 : 1;
+
+	return (write_return);
 }

--- a/print_decimal.c
+++ b/print_decimal.c
@@ -5,19 +5,36 @@
 /**
  * recursive_int - Function aux for diplay the numbers
  * @n: The number (unsigned for manage INT_MIN)
- * Return: Numbers of charcaters display
+ * @count: Pointer to the "internal print counter"
+ * Return: -1 on failure, 0 on success.
+ *
+ * NOTE: prototype changed to include a pointer to "caller counter"
+ *   in order to separate the logic for counting successful writes
+ *   and the logic for "bubbling up the error code case arising".
+ *   Of course it wasn't the only way to do so, but I find it simple.
+ *  Also, func returns 0 on success and not 1 to avoid any confusion
+ *   on responsability and meaning of its return (since now the count
+ *   is taken care of with a cross-func shared integer pointer).
  */
-int recursive_int(unsigned int n)
+int recursive_int(unsigned int n, int *count)
 {
-	int count = 0;
 	char digit;
 
+	/* While number is >= 10 we "consume" recursively with division by 10 */
 	if (n / 10)
-	count += recursive_int(n / 10);
+	{
+		if (recursive_int(n / 10, count) < 0)
+			return (-1);
+	}
 
+	/* Process for the unit digit of number in stack frame */
 	digit = (n % 10) + '0';
-	write(1, &digit, 1);
-	return (count + 1);
+	/* Works but hard to read. */
+	/*return ((write(1, &digit, 1) < 0) ? -1 : ++(*count)); */
+	if ((write(1, &digit, 1) < 0))
+		return (-1);
+	(*count)++;
+	return (0);
 }
 
 /**
@@ -34,17 +51,20 @@ int print_decimal(va_list args)
 	/* Gestion du signe négatif */
 	if (n < 0)
 	{
-	write(1, "-", 1);
-	count++;
-	abs_n = (unsigned int)(-n);
+		if (write(1, "-", 1) < 0)
+			return (-1);
+		count++;
+		abs_n = (unsigned int)(-n);
 	}
 	else
-	{
-	abs_n = (unsigned int)n;
-	}
+		abs_n = (unsigned int)n;
 
 	/* Appel de la fonction récursive pour afficher les chiffres */
-	count += recursive_int(abs_n);
+	/* count += recursive_int(abs_n); */
+	/* Changed to allow "error bubbling up". Counter incremented inside. */
+	if (recursive_int(abs_n, &count) < 0)
+		return (-1);
+	/* Above stops when one digit cannot be printed (count is then "lost"). */
 
 	return (count);
 }

--- a/print_string.c
+++ b/print_string.c
@@ -11,6 +11,7 @@ int print_string(va_list args)
 {
 	char *str;
 	int i = 0;
+	int write_success;
 
 	/* On récupère l'argument de type char* */
 	str = va_arg(args, char *);
@@ -22,8 +23,10 @@ int print_string(va_list args)
 	/* On boucle sur la chaîne et on affiche chaque caractère */
 	while (str[i] != '\0')
 	{
-	write(1, &str[i], 1);
-	i++;
+		write_success = write(1, &str[i], 1);
+		if (write_success < 0)
+			return (-1);
+		i++;
 	}
 
 	/* retourne le nombre de caractères écrits (i) */

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <limits.h>
-#include "main.h"
+#include "../main.h"
 
 
 /* Helper required because a static directly in macro */


### PR DESCRIPTION
### CHANGED

#### FIXES
- Header include path was broken in test_main for "demonstrator exe" compilation (also fixed the doc to specify the Wno-format option).
- For print_character the EOL in previous code may not have always returned 1 on successful write.

#### IMPROVEMENTS
- The %d, %i and %s now properly bubble back any error code that may be sent by "write" function during writing loops.

#### MINOR
- Remove of obsolete include in _prinft.

### NOTES
Betty reports a false positive on the line 28 of _printf.c enabling the "print_unsigned" in correspondance table. This is actually a bug caused by a not constrained enough pattern search in the betty linter. A bug will soon be submitted on that.